### PR TITLE
Allow selecting db instance class instead of defaulting to t2 micro (…

### DIFF
--- a/database/postgres/main.tf
+++ b/database/postgres/main.tf
@@ -29,6 +29,7 @@ module "postgres" {
   db_port             = var.db_port
   skip_final_snapshot = var.skip_final_snapshot
   engine_version      = var.engine_version
+  db_instance_class   = var.db_instance_class
 }
 
 module "param_store_pghost" {

--- a/database/postgres/vars.tf
+++ b/database/postgres/vars.tf
@@ -38,3 +38,8 @@ variable "engine_version" {
   description = "RDS engine version"
   default     = null
 }
+variable "db_instance_class" {
+  type        = string
+  description = "RDS database instance class"
+  default     = "db.t2.micro"
+}


### PR DESCRIPTION
…#198)

Co-authored-by: mamor <mamor@dfds.com>